### PR TITLE
Added a timeout of 5 seconds for notification alerts

### DIFF
--- a/src/helpers/mappers.js
+++ b/src/helpers/mappers.js
@@ -37,6 +37,8 @@ exports.notificationData = function(data) {
     message: data.item.album.name,
     group: 'Spotify',
     remove: 'ALL',
-    sender: 'com.spotify.client'
+    sender: 'com.spotify.client',
+    timeout: '5',
+    actions: 'Next Song' 
   };
 };


### PR DESCRIPTION
## What does this PR do?

Adds a 5 second timeout to notifications so even Notification Alerts get dismissed automatically when displayed.

## Critical points

I'm not quite sure why, but whenever the Notification Alert button that isn't the "Close" button is clicked, Spotify skips tracks even though I haven't programmed it to do that. Because of that, I've just changed the button's label from the default "Open" to "Next Song". 