### PR TITLE
Add album art to notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 dist
 .env.json
 electron-builder.yml
+.idea/
+yarn-error.log

--- a/src/domain/spotify-player.js
+++ b/src/domain/spotify-player.js
@@ -38,7 +38,7 @@ exports.execute = function(parentWindow, tray) {
         if(json.item) {
           const mappedData = mappers.currentPlaybackToView(json);
           if(shouldShowTrackNotification(mappedData)) {
-            notifier.notify(mappers.notificationData(json));
+            notifier.notify(mappers.notificationData(mappedData));
           }
           if(shouldShowSongMenubar()) {
             const title = `${mappedData.artistName} - ${mappedData.musicName} - ${mappedData.albumName}`;

--- a/src/helpers/mappers.js
+++ b/src/helpers/mappers.js
@@ -28,13 +28,12 @@ exports.playlistsToView = function(data) {
   }));
 };
 
-exports.notificationData = function(data) {
-  const artistName = data.item.artists.map(artist => artist.name).join(', ');
-    
+exports.notificationData = function(mappedData) {
   return {
-    title: data.item.name,
-    subtitle: artistName, 
-    message: data.item.album.name,
+    title: mappedData.musicName,
+    subtitle: mappedData.artistName,
+    message: mappedData.albumName,
+    contentImage: mappedData.albumImageSrc,
     group: 'Spotify',
     remove: 'ALL',
     sender: 'com.spotify.client',


### PR DESCRIPTION
## What does this PR do?

_Is this a bugfix or an improvement?;_

Enhancement.

_Explain the changes this PR brings to the project;_

Album art is added to the notifications, if notifications are enabled.

_Mention a issue (adding the link, of course) if there is any relationship;_

#35 is partially fixed by this PR.

_Insert some print screen of the result, if it changes the UI._

![image](https://user-images.githubusercontent.com/15013453/119115960-1d410700-ba6b-11eb-8de3-15ceb7d813fa.png)

## How to test?

_Explain how to test in localhost and/or with the build app (what to do, which songs if necessary, etc)._

Run the app using `yarn start` and turn on notifications in System Preferences -> Spotify.

## Critical points

_Is there any part of the code that deserves more attention?;_

Not that I can see as of yet.

_Any technical debt produced by this code? Something could be done better but it wasn't? Why?._

Don't think so, very little code was changed.

Thanks!