### PR TITLE
take out `cask` from install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Download the `.dmg` file from the [latest release](https://github.com/davicorrei
 
 Using Homebrew:
 ```
-brew cask install spotify-now-playing
+brew install spotify-now-playing
 ```
 
 ### Compatibily with Linux


### PR DESCRIPTION
updated versions of homebrew no longer expect / accept the `cask` option.

`brew cask install` -> `brew install` in the installation instructions.

## What does this PR do?
_Is this a bugfix or an improvement?;_

_Explain the changes this PR brings to the project;_

_Mention a issue (adding the link, of course) if there is any relationship;_

_Insert some print screen of the result, if it changes the UI._

## How to test?
_Explain how to test in localhost and/or with the build app (what to do, which songs if necessary, etc)._

## Critical points
_Is there any part of the code that deserves more attention?;_

_Any technical debt produced by this code? Something could be done better but it wasn't? Why?._